### PR TITLE
Add table data pull request count

### DIFF
--- a/lib/github_data_provider.rb
+++ b/lib/github_data_provider.rb
@@ -3,6 +3,7 @@
 require_relative "github_data_provider/version"
 require_relative "github_data_provider/configuration"
 require_relative "github_data_provider/client"
+require_relative "github_data_provider/pull_request_count"
 
 module GithubDataProvider
 

--- a/lib/github_data_provider/pull_request_count.rb
+++ b/lib/github_data_provider/pull_request_count.rb
@@ -1,0 +1,39 @@
+module GithubDataProvider
+  class PullRequestCount
+    Response = Struct.new(:data, :expires_in)
+
+    def initialize(options = {})
+      @options = options
+      set_options_defaults
+    end
+
+    def fetch
+      Response.new(
+        [ClosedPRCountLeaderboard.new(source_data).parse],
+        expires_in
+      )
+    end
+
+    private
+
+    def source_data
+      JSON.parse(client.get(endpoint_uri))
+    end
+
+    def client
+      @_client ||= GithubDataProvider::Client.new(GithubDataProvider.configuration)
+    end
+
+    def endpoint_uri
+      "/search/issues?q=type:pr+org:#{@options[:org]}"
+    end
+
+    def set_options_defaults
+      @options[:org] ||= "Standout"
+    end
+
+    def expires_in
+      60**2
+    end
+  end
+end

--- a/lib/github_data_provider/pull_request_count/closed_pr_count_leaderboard.rb
+++ b/lib/github_data_provider/pull_request_count/closed_pr_count_leaderboard.rb
@@ -1,0 +1,30 @@
+module GithubDataProvider
+  class PullRequestCount::ClosedPRCountLeaderboard
+    # Expects the source data as a hash
+    def initialize(source_data)
+      @source_data = source_data
+    end
+
+    def parse
+      {
+        type: "table",
+        title: "Antal pull requests",
+        meta: { headers: ['Namn', 'Stängda'] },
+        data: array_data
+      }
+    end
+
+    private
+
+    def hash_data
+      @source_data["items"].each_with_object({}) do |item, hash|
+        hash[item["user"]["login"]] ||= 0
+        hash[item["user"]["login"]] += 1 if item["state"] == "closed"
+      end
+    end
+
+    def array_data
+      hash_data.map(&:to_a).sort_by {|_k, v| v }.reverse
+    end
+  end
+end

--- a/spec/unit/pull_request_count/closed_pr_count_leaderboard_spec.rb
+++ b/spec/unit/pull_request_count/closed_pr_count_leaderboard_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "github_data_provider/pull_request_count/closed_pr_count_leaderboard"
+
+RSpec.describe GithubDataProvider::PullRequestCount::ClosedPRCountLeaderboard do
+  let(:source_data) do
+    {
+      "total_count": 280,
+      "incomplete_results": false,
+      "items": [
+        {
+          "user": { "login": "Bob", "id": 1,
+            "avatar_url": "https://secure.gravatar.com/avatar/934442aadfe3b2f4630510de416c5718?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png",
+          },
+          "created_at": "2009-07-12T20:10:41Z",
+          "updated_at": "2009-07-19T09:23:43Z",
+          "closed_at": nil,
+        }
+      ]
+    }
+  end
+
+  it "counts closed pull requests for a login" do
+    source_data = {
+      "items" => [
+        {
+          "user" => { "login" => "Bob" },
+          "state" => "closed"
+        },
+        {
+          "user" => { "login" => "Fredrik" },
+          "state" => "open"
+        },
+        {
+          "user" => { "login" => "Bob" },
+          "state" => "closed"
+        }
+      ]
+    }
+
+    data = GithubDataProvider::PullRequestCount::ClosedPRCountLeaderboard.new(source_data).parse
+
+    expect(data).to include(
+      data: [
+        [ "Bob", 2],
+        [ "Fredrik", 0],
+      ]
+    )
+  end
+
+  it "includes metadata" do
+    source_data = {
+      "items" => []
+    }
+
+    data = GithubDataProvider::PullRequestCount::ClosedPRCountLeaderboard.new(source_data).parse
+
+    expect(data).to include(
+      type: "table",
+      title: "Antal pull requests",
+      meta: { headers: ['Namn', 'Stängda'] }
+    )
+  end
+
+  it "sorts the entries" do
+    source_data = {
+      "items" => [
+        {
+          "user" => { "login" => "Bob" },
+          "state" => "closed"
+        },
+        {
+          "user" => { "login" => "Fredrik" },
+          "state" => "open"
+        },
+        {
+          "user" => { "login" => "Bob" },
+          "state" => "closed"
+        },
+        {
+          "user" => { "login" => "BruceTheAllmighty" },
+          "state" => "closed"
+        },
+        {
+          "user" => { "login" => "BruceTheAllmighty" },
+          "state" => "closed"
+        },
+        {
+          "user" => { "login" => "BruceTheAllmighty" },
+          "state" => "closed"
+        }
+      ]
+    }
+
+    data = GithubDataProvider::PullRequestCount::ClosedPRCountLeaderboard.new(source_data).parse
+
+    expect(data).to include(
+      {
+        data: [
+          [ "BruceTheAllmighty", 3],
+          [ "Bob", 2],
+          [ "Fredrik", 0],
+        ]
+      }
+    )
+  end
+end

--- a/spec/unit/pull_request_count_spec.rb
+++ b/spec/unit/pull_request_count_spec.rb
@@ -3,18 +3,18 @@
 RSpec.describe GithubDataProvider::PullRequestCount do
   let(:default_response_body) do
     {
-      "total_count": 280,
-      "incomplete_results": false,
-      "items": [
+      "total_count" => 280,
+      "incomplete_results" => false,
+      "items" => [
         {
-          "user": {
-            "login": "Bob",
-            "id": 1,
-            "avatar_url": "https://secure.gravatar.com/avatar/934442aadfe3b2f4630510de416c5718?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png",
+          "user" => {
+            "login" => "Bob",
+            "id" => 1,
+            "avatar_url" => "https://secure.gravatar.com/avatar/934442aadfe3b2f4630510de416c5718?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png",
           },
-          "created_at": "2009-07-12T20:10:41Z",
-          "updated_at": "2009-07-19T09:23:43Z",
-          "closed_at": nil,
+          "created_at" => "2009-07-12T20:10:41Z",
+          "updated_at" => "2009-07-19T09:23:43Z",
+          "closed_at" => nil,
         }
       ]
     }

--- a/spec/unit/pull_request_count_spec.rb
+++ b/spec/unit/pull_request_count_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe GithubDataProvider::PullRequestCount do
+  let(:default_response_body) do
+    {
+      "total_count": 280,
+      "incomplete_results": false,
+      "items": [
+        {
+          "user": {
+            "login": "Bob",
+            "id": 1,
+            "avatar_url": "https://secure.gravatar.com/avatar/934442aadfe3b2f4630510de416c5718?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png",
+          },
+          "created_at": "2009-07-12T20:10:41Z",
+          "updated_at": "2009-07-19T09:23:43Z",
+          "closed_at": nil,
+        }
+      ]
+    }
+  end
+  let(:url) { "https://api.github.com/search/issues?q=type:pr+org:Standout" }
+
+  it "expires in an hour" do
+    stub_request(:get, url).to_return(body: default_response_body.to_json)
+    service = GithubDataProvider::PullRequestCount.new
+
+    response = service.fetch
+
+    expect(response.expires_in).to eq 60**2
+  end
+
+  it "returns an array with data" do
+    stub_request(:get, url).to_return(body: default_response_body.to_json)
+    service = GithubDataProvider::PullRequestCount.new
+
+    response = service.fetch
+
+    expect(response.data).to be_a_kind_of Array
+  end
+end


### PR DESCRIPTION
# Add table data pull request count
You can now retrieve statistics about closed pull requests for your provided organization.